### PR TITLE
Add function to get proxy dicts for Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,12 @@ make install
 import proxlist
 import requests
 
-proxy = proxlist.random_proxy()
+proxies = proxlist.proxy_dict()
 
-# Alternatively, you could get the entire list of configured proxies
+# Alternatively, you could get a single proxy
+# proxy = proxlist.random_proxy()
+# or a list of configured proxies
 # proxies = proxlist.list_proxies()
-
-proxies = {
-    'http': f'http://{proxy}',
-    'https': f'http://{proxy}',
-}
 
 response = requests.get('https://google.com', proxies=proxies)
 print(response.text)

--- a/proxlist/__init__.py
+++ b/proxlist/__init__.py
@@ -1,6 +1,7 @@
-from proxlist.proxies import list_proxies, random_proxy
+from proxlist.proxies import list_proxies, random_proxy, proxy_dict
 
 __all__ = [
     'random_proxy',
     'list_proxies',
+    'proxy_dict'
 ]

--- a/proxlist/proxies.py
+++ b/proxlist/proxies.py
@@ -30,3 +30,11 @@ def random_proxy() -> str:
 
 def list_proxies() -> List[str]:
     return PROXY_LIST
+
+
+def proxy_dict() -> dict:
+    proxy = random_proxy()
+    return {
+        'http': f'http://{proxy}',
+        'https': f'https://{proxy}',
+    }

--- a/proxlist/proxies.py
+++ b/proxlist/proxies.py
@@ -34,6 +34,12 @@ def list_proxies() -> List[str]:
 
 
 def proxy_dict() -> Dict[str, str]:
+    """
+    Returns a proxy dictionary, perfect for passing into the requests `proxies` parameter
+    
+    :return: A dictionary of proxy details
+    :rtype: dict
+    """
     proxy = random_proxy()
     proxy_dict = {
         'http': f'http://{proxy}',

--- a/proxlist/proxies.py
+++ b/proxlist/proxies.py
@@ -32,7 +32,7 @@ def list_proxies() -> List[str]:
     return PROXY_LIST
 
 
-def proxy_dict() -> dict:
+def proxy_dict() -> Dict[str, str]:
     proxy = random_proxy()
     return {
         'http': f'http://{proxy}',

--- a/proxlist/proxies.py
+++ b/proxlist/proxies.py
@@ -34,7 +34,8 @@ def list_proxies() -> List[str]:
 
 def proxy_dict() -> Dict[str, str]:
     proxy = random_proxy()
-    return {
+    proxy_dict = {
         'http': f'http://{proxy}',
         'https': f'https://{proxy}',
     }
+    return proxy_dict

--- a/proxlist/proxies.py
+++ b/proxlist/proxies.py
@@ -29,6 +29,7 @@ def random_proxy() -> str:
 
 
 def list_proxies() -> List[str]:
+    
     return PROXY_LIST
 
 
@@ -38,4 +39,5 @@ def proxy_dict() -> Dict[str, str]:
         'http': f'http://{proxy}',
         'https': f'https://{proxy}',
     }
+    
     return proxy_dict

--- a/test/unit/test_proxies.py
+++ b/test/unit/test_proxies.py
@@ -11,3 +11,16 @@ def test_list_proxies():
     proxy_list = proxlist.list_proxies()
 
     assert proxy_list == proxlist.proxies.PROXY_LIST
+
+    
+def test_proxy_dict():
+    proxy_dict = proxlist.proxy_dict()
+    http = proxy_dict.get('http', None)
+    https = proxy_dict.get('https', None)
+
+
+    assert proxy_dict is not None
+    assert http is not None
+    assert http.startswith('http://')
+    assert https is not None
+    assert https.startswith('https://')


### PR DESCRIPTION
Adds a `proxy_dict()` function to retrieve a ready-to-use `proxies` parameter for the `requests` library.